### PR TITLE
✨ 회원 목록 조회 기능 구현

### DIFF
--- a/auths/views.py
+++ b/auths/views.py
@@ -106,7 +106,8 @@ def verify(request):
 @permission_classes([IsAuthenticated])
 def user_detail(request):
     if request.method == 'GET':
-        serializer = MutsaUserResponseSerializer(request.user)
+        users = MutsaUser.objects.all()
+        serializer = MutsaUserResponseSerializer(users, many=True)
         return Response(serializer.data)
     elif request.method == 'PATCH':
         user = MutsaUser.objects.get(nickname=request.user.nickname)
@@ -120,3 +121,9 @@ def user_detail(request):
         
         serializer = MutsaUserResponseSerializer(request.user)
         return Response(serializer.data)
+    
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def user_my_detail(request):
+    serializer = MutsaUserResponseSerializer(request.user)
+    return Response(serializer.data)

--- a/config/urls.py
+++ b/config/urls.py
@@ -17,7 +17,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 
-from auths.views import kakao_login, verify, user_detail
+from auths.views import kakao_login, verify, user_detail, user_my_detail
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -26,4 +26,5 @@ urlpatterns = [
     path('auth/verify', verify),
 
     path('users', user_detail),
+    path('users/me', user_my_detail),
 ]


### PR DESCRIPTION
로그인한 회원이 모든 회원들의 목록을 조회할 수 있습니다.

# config/urls.py
본인 프로필 조회는 /users/me로 빼고, /users에 GET을 하면 목록을 조회하도록 했습니다.

# auths/views.py
본인 프로필 조회는 별도 메서드 user_my_detail로 빼고, user_detail에 목록 조회 코드를 작성했습니다.